### PR TITLE
Add option to remove duplicate and list all headers on a single line

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,7 +31,7 @@ browser.storage.local.get(["headerNumbers", "regexp"]).then(({headerNumbers, reg
 
 function displayReceivedHeader(tabId, messageId) {
     browser.messages.getFull(messageId).then((messagepart) => {
-        browser.storage.local.get(["headerNumbers", "regexp"]).then(({headerNumbers, regexp}) => {
+        browser.storage.local.get(["headerNumbers", "regexp", "removeDuplicates", "singleLine"]).then(({headerNumbers, regexp, removeDuplicates, singleLine}) => {
             let headers = [];
             let numberFound = false;
 
@@ -47,8 +47,23 @@ function displayReceivedHeader(tabId, messageId) {
 
             if (headers.length) {
                 const parsed = parseReceivedHeaders(headers, regexp);
-                browser.displayReceivedHeader.setReceivedHeaderValue(tabId, parsed);
-                browser.displayReceivedHeader.setReceivedHeaderHidden(tabId, !parsed.length);
+                let filteredParsed = [];
+
+                if (removeDuplicates) {
+                    let alreadyAdded = [];
+                    for (let item of parsed) {
+                        const key = item.join("_");
+                        if (alreadyAdded.indexOf(key) === -1) {
+                            filteredParsed.push(item);
+                            alreadyAdded.push(key);
+                        }
+                     }
+                } else {
+                    filteredParsed = parsed;
+                }
+
+                browser.displayReceivedHeader.setReceivedHeaderValue(tabId, filteredParsed, singleLine);
+                browser.displayReceivedHeader.setReceivedHeaderHidden(tabId, !filteredParsed.length);
             } else {
                 browser.displayReceivedHeader.setReceivedHeaderHidden(tabId, true);
             }

--- a/experiments/displayReceivedHeader.js
+++ b/experiments/displayReceivedHeader.js
@@ -80,24 +80,43 @@ var displayReceivedHeader = class extends ExtensionCommon.ExtensionAPI {
                     mailHeaderfield.hidden = hidden;
                     if (majorVersion >= 100) syncGridColumnWidths(document);
                 },
-                setReceivedHeaderValue(tabId, headersArray) {
+                setReceivedHeaderValue(tabId, headersArray, singleLine) {
                     const document = getDocumentByTabId(tabId);
                     if (!document) return;
 
                     const headerRowValue = document.createElement("td");
                     headerRowValue.id = "receivedReceivedHeader";
+                    let mailHeaderfield;
+
+                    if (singleLine) {
+                        mailHeaderfield = document.createXULElement("mail-headerfield");
+                        mailHeaderfield.flex = "1";
+                    }
 
                     headersArray.forEach(function (header) {
-                        const mailHeaderfield = document.createXULElement("mail-headerfield");
-                        mailHeaderfield.flex = "1";
+                        if (!singleLine) {
+                            mailHeaderfield = document.createXULElement("mail-headerfield");
+                            mailHeaderfield.flex = "1";
+                        }
+
+                        if (mailHeaderfield.textContent !== "") {
+                            mailHeaderfield.textContent += ", ";
+                        }
+
                         header.forEach(function (string) {
                             mailHeaderfield.textContent += string;
                         });
 
-                        headerRowValue.appendChild(mailHeaderfield);
+                        if (!singleLine) {
+                            headerRowValue.appendChild(mailHeaderfield);
+                        }
                     });
 
-                    const mailHeaderfield = document.getElementById("expandedReceivedRow");
+                    if (singleLine) {
+                        headerRowValue.appendChild(mailHeaderfield);
+                    }
+
+                    mailHeaderfield = document.getElementById("expandedReceivedRow");
                     const oldChild = document.getElementById("receivedReceivedHeader");
                     mailHeaderfield.replaceChild(headerRowValue, oldChild);
                 },

--- a/experiments/displayReceivedHeader.json
+++ b/experiments/displayReceivedHeader.json
@@ -47,6 +47,11 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "singleLine",
+            "description": "List all headers on a single line",
+            "type": "boolean"
           }
         ]
       }

--- a/options/options.html
+++ b/options/options.html
@@ -66,6 +66,18 @@
                 </label>
                 <input type="text" id="regexp" />
             </p>
+            <p>
+                <label for="remove-duplicates">
+                    Remove duplicates:
+                </label>
+                <input type="checkbox" id="remove-duplicates" />
+            </p>
+            <p>
+                <label for="single-line">
+                    Single line:
+                </label>
+                <input type="checkbox" id="single-line" />
+            </p>
             <button type="submit">Save</button>
         </form>
     </div>

--- a/options/options.js
+++ b/options/options.js
@@ -7,14 +7,18 @@ function saveOptions(e) {
 
     browser.storage.local.set({
         headerNumbers: document.querySelector("#header-numbers").value,
-        regexp: document.querySelector("#regexp").value
+        regexp: document.querySelector("#regexp").value,
+        removeDuplicates: document.querySelector("#remove-duplicates").checked,
+        singleLine: document.querySelector("#single-line").checked
     });
 }
 
 function restoreOptions() {
-    browser.storage.local.get(["headerNumbers", "regexp"]).then(({headerNumbers, regexp}) => {
+    browser.storage.local.get(["headerNumbers", "regexp", "removeDuplicates", "singleLine"]).then(({headerNumbers, regexp, removeDuplicates, singleLine}) => {
         document.querySelector("#header-numbers").value = headerNumbers;
         document.querySelector("#regexp").value = regexp;
+        document.querySelector("#remove-duplicates").checked = removeDuplicates;
+        document.querySelector("#single-line").checked = singleLine;
     });
 }
 


### PR DESCRIPTION
Hello,

This PR add two options:

* An option to remove duplicates in parsed headers
* An option to display headers on a single line

This allowed me to display a list unique servers a mail transited through in a single line :)