### PR TITLE
Use Services global variable if possible

### DIFF
--- a/experiments/displayReceivedHeader.js
+++ b/experiments/displayReceivedHeader.js
@@ -1,10 +1,10 @@
-/* global ChromeUtils */
+/* global ChromeUtils, globalThis */
 /* exported displayReceivedHeader */
 
 "use strict";
 
 const {ExtensionCommon} = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const Services = globalThis.Services || ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 const [majorVersion] = Services.appinfo.platformVersion.split(".", 1);
 
 // eslint-disable-next-line no-var


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.